### PR TITLE
Fix background image paths for Vercel deployment

### DIFF
--- a/RAC IIE.html
+++ b/RAC IIE.html
@@ -31,7 +31,7 @@
     <style>
         /* Additional custom styles can go here if needed */
         .hero-bg {
-            background-image: linear-gradient(rgba(17, 24, 39, 0.8), rgba(17, 24, 39, 0.8)), url('assets/images/gallery/homeimg.jpg');
+            background-image: linear-gradient(rgba(17, 24, 39, 0.8), rgba(17, 24, 39, 0.8)), url('/assets/images/gallery/homeimg.jpg');
             background-size: cover;
             background-position: center;
         }
@@ -103,7 +103,7 @@
             bottom: -100%;
             left: 10%;
             transition: all 0.2s;
-            background-image: url('assets/images/gallery/goblin.png');
+            background-image: url('/assets/images/gallery/goblin.png');
             background-size: cover;
             border-radius: 50%;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,21 @@
       "name": "rotaract-club-website",
       "version": "1.0.0",
       "dependencies": {
+        "@vercel/blob": "^0.23.3",
         "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "mongodb": "^5.9.2",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "serverless-http": "^3.2.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -49,6 +60,22 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-0.23.4.tgz",
+      "integrity": "sha512-cOU2e01RWZXFyc/OVRq+zZg38m34bcxpQk5insKp3Td9akNWThrXiF2URFHpRlm4fbaQ/l7pPSOB5nkLq+t6pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "bytes": "^3.1.2",
+        "is-buffer": "^2.0.5",
+        "is-plain-object": "^5.0.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -73,6 +100,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -543,6 +579,38 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -847,6 +915,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -925,6 +1002,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -1104,6 +1190,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",


### PR DESCRIPTION
## Purpose
The user deployed their project to Vercel but encountered an issue where the background image on the home screen was not rendering properly. This fix addresses the image path issue to ensure proper display in the Vercel deployment environment.

## Code changes
- **Fixed image paths**: Updated background image URLs from relative paths (`assets/images/...`) to absolute paths (`/assets/images/...`) in the hero background and goblin image
- **Added Vercel dependencies**: Installed `@vercel/blob` and `serverless-http` packages to support Vercel deployment infrastructure
- **Updated package.json**: Added new dependencies for Vercel blob storage and serverless HTTP handlingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc965b5408cd42c19176a58ca3b8d360/pulse-den)

👀 [Preview Link](https://dc965b5408cd42c19176a58ca3b8d360-pulse-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc965b5408cd42c19176a58ca3b8d360</projectId>-->
<!--<branchName>pulse-den</branchName>-->