### PR TITLE
Fix API routing for Vercel deployment

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,6 +12,14 @@ require('dotenv').config();
 const app = express();
 app.use(express.json({ limit: '1mb' }));
 
+// Normalize Vercel rewrite path: /api/(.*) -> /api/index/$1
+// This lets existing '/api/...' routes keep working when the function is '/api/index.js'.
+app.use((req, res, next) => {
+  if (req.url === '/api/index') req.url = '/api';
+  else if (req.url.startsWith('/api/index/')) req.url = req.url.replace(/^\/api\/index\//, '/api/');
+  next();
+});
+
 // Helpers
 function basicAuth(req, res, next) {
   const header = req.headers['authorization'] || '';

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "rewrites": [
     { "source": "/", "destination": "/index.html" },
-    { "source": "/admin", "destination": "/admin.html" }
+    { "source": "/admin", "destination": "/admin.html" },
+    { "source": "/api/(.*)", "destination": "/api/index/$1" }
   ]
 }


### PR DESCRIPTION
## Purpose
Fix API routing issues on the live Vercel deployment where project cards were not rendering and admin page data was not being fetched due to incorrect API path handling.

## Code changes
- **Added Vercel rewrite rule** in `vercel.json` to route `/api/(.*)` requests to `/api/index/$1`
- **Added path normalization middleware** in `api/index.js` to handle the rewritten paths by converting `/api/index` back to `/api` and `/api/index/...` back to `/api/...`
- This ensures existing API routes continue working correctly when the serverless function is deployed as `/api/index.js` on VercelTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a338d361b4244abfa76b1a3ffc69e5fd/curry-garden)

👀 [Preview Link](https://a338d361b4244abfa76b1a3ffc69e5fd-curry-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a338d361b4244abfa76b1a3ffc69e5fd</projectId>-->
<!--<branchName>curry-garden</branchName>-->